### PR TITLE
nil check and fix convert byte

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,20 +50,20 @@ func meminfoValue(v *uint64) float64 {
 	if v == nil {
 		return 0
 	}
-	return float64(*v * 1024)
+	return float64(*v) * 1024
 }
 
 func meminfoSub(total *uint64, subs ...*uint64) float64 {
 	if total == nil {
 		return 0
 	}
-	remaining := *total
+	remaining := float64(*total)
 	for _, v := range subs {
 		if v != nil {
-			remaining -= *v
+			remaining -= float64(*v)
 		}
 	}
-	return float64(remaining * 1024)
+	return remaining * 1024
 }
 
 func (u LinuxMemoryPlugin) FetchMetrics() (map[string]float64, error) {

--- a/main.go
+++ b/main.go
@@ -46,6 +46,26 @@ func (u LinuxMemoryPlugin) MetricKeyPrefix() string {
 	return "linux-memory"
 }
 
+func meminfoValue(v *uint64) float64 {
+	if v == nil {
+		return 0
+	}
+	return float64(*v * 1024)
+}
+
+func meminfoSub(total *uint64, subs ...*uint64) float64 {
+	if total == nil {
+		return 0
+	}
+	remaining := *total
+	for _, v := range subs {
+		if v != nil {
+			remaining -= *v
+		}
+	}
+	return float64(remaining * 1024)
+}
+
 func (u LinuxMemoryPlugin) FetchMetrics() (map[string]float64, error) {
 	fs, err := procfs.NewFS("/proc")
 	if err != nil {
@@ -57,23 +77,23 @@ func (u LinuxMemoryPlugin) FetchMetrics() (map[string]float64, error) {
 	}
 
 	result := map[string]float64{
-		"total":       float64(*m.MemTotal * 1024),
-		"kernelstack": float64(*m.KernelStack * 1024),
-		"vmallocused": float64(*m.VmallocUsed * 1024),
-		"pagetables":  float64(*m.PageTables * 1024),
-		"mapped":      float64(*m.Mapped * 1024),
-		"anonpages":   float64(*m.AnonPages * 1024),
-		"slab":        float64(*m.Slab * 1024),
-		"buffers":     float64(*m.Buffers * 1024),
-		"cached":      float64(*m.Cached * 1024),
-		"free":        float64(*m.MemFree * 1024),
+		"total":       meminfoValue(m.MemTotal),
+		"kernelstack": meminfoValue(m.KernelStack),
+		"vmallocused": meminfoValue(m.VmallocUsed),
+		"pagetables":  meminfoValue(m.PageTables),
+		"mapped":      meminfoValue(m.Mapped),
+		"anonpages":   meminfoValue(m.AnonPages),
+		"slab":        meminfoValue(m.Slab),
+		"buffers":     meminfoValue(m.Buffers),
+		"cached":      meminfoValue(m.Cached),
+		"free":        meminfoValue(m.MemFree),
 	}
 
 	if m.MemAvailable != nil {
-		result["used"] = float64((*m.MemTotal - *m.MemAvailable) * 1024)
-		result["available"] = float64(*m.MemAvailable * 1024)
+		result["used"] = meminfoSub(m.MemTotal, m.MemAvailable)
+		result["available"] = meminfoValue(m.MemAvailable)
 	} else {
-		result["used"] = float64(*m.MemTotal - *m.MemFree - *m.Buffers - *m.Cached)
+		result["used"] = meminfoSub(m.MemTotal, m.MemFree, m.Buffers, m.Cached)
 	}
 
 	return result, nil


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add nil-safe helpers for `/proc/meminfo` values

- Prevent uint64 overflow when converting to bytes

- Refactor used/available memory calculations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  meminfo["procfs.Meminfo pointers"] --> meminfoValue["meminfoValue() nil-safe conversion"]
  meminfo --> meminfoSub["meminfoSub() nil-safe subtraction"]
  meminfoValue --> result["metric map"]
  meminfoSub --> result
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Safely convert meminfo values and prevent overflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.go

<ul><li>Added <code>meminfoValue</code> helper that returns <code>0</code> for nil <code>*uint64</code> values and <br>converts to <code>float64</code> before multiplying by <code>1024</code><br> <li> Added <code>meminfoSub</code> helper that safely subtracts optional subtrahends <br>from a total and converts to bytes<br> <li> Replaced direct pointer dereferences and integer arithmetic in <br><code>FetchMetrics</code> with the new helpers to avoid nil panics and uint64 <br>overflow</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-linux-memory/pull/6/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+33/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

